### PR TITLE
FIx Client Public Routes 

### DIFF
--- a/apps/api/src/lib/functions/middleware.ts
+++ b/apps/api/src/lib/functions/middleware.ts
@@ -25,12 +25,11 @@ export async function setUserSessionContextMiddleware(c: Context, next: Next) {
 		c.set("user", null);
 		c.set("session", null);
 		c.set("teamId", null);
-	}
-	else{
+	} else {
 		c.set("user", session.user);
 		c.set("session", session.session);
 	}
-	
+
 	await next();
 }
 

--- a/apps/api/src/lib/functions/middleware.ts
+++ b/apps/api/src/lib/functions/middleware.ts
@@ -3,9 +3,8 @@ import { auth } from "../auth";
 import { logInfo } from "./database";
 import { nanoid } from "nanoid";
 import type { ApiContext } from "../types";
-import { API_ERROR_MESSAGES } from "shared";
+import { API_ERROR_MESSAGES, API_MIDDLEWARE_PUBLIC_ROUTES } from "shared";
 
-export const MIDDLEWARE_PUBLIC_ROUTES = ["/health", "/api/auth"];
 /**
  * Middleware to set user and session context for each request. This middleware checks the authentication status of the incoming request, retrieves the user session if it exists, and sets relevant information in the context for downstream handlers to use. It also logs the request path and authentication status for monitoring purposes.
  * @param c - The Hono context object
@@ -26,11 +25,12 @@ export async function setUserSessionContextMiddleware(c: Context, next: Next) {
 		c.set("user", null);
 		c.set("session", null);
 		c.set("teamId", null);
-		return next();
 	}
-
-	c.set("user", session.user);
-	c.set("session", session.session);
+	else{
+		c.set("user", session.user);
+		c.set("session", session.session);
+	}
+	
 	await next();
 }
 
@@ -40,9 +40,12 @@ export async function setUserSessionContextMiddleware(c: Context, next: Next) {
  * @param next - The next middleware function in the chain
  */
 export async function authenticatedMiddleware(c: ApiContext, next: Next) {
-	const isPublicRoute = MIDDLEWARE_PUBLIC_ROUTES.some((route) =>
-		c.req.path.startsWith(route),
-	);
+	const isPublicRoute = API_MIDDLEWARE_PUBLIC_ROUTES.some((route) => {
+		if (route instanceof RegExp) {
+			return route.test(c.req.path);
+		}
+		return c.req.path.startsWith(route);
+	});
 	if (isPublicRoute) {
 		return next();
 	}

--- a/apps/web/src/lib/functions/auth.ts
+++ b/apps/web/src/lib/functions/auth.ts
@@ -8,7 +8,12 @@ import { redirect } from "@tanstack/react-router";
  * @returns True if the pathname is a public route, false otherwise
  */
 export function isPublicRoute(pathname: string) {
-	return PUBLIC_ROUTES.includes(pathname);
+	return PUBLIC_ROUTES.some((route) => {
+		if (route instanceof RegExp) {
+			return route.test(pathname);
+		}
+		return pathname === route;
+	});
 }
 
 /**

--- a/packages/shared/constants.ts
+++ b/packages/shared/constants.ts
@@ -55,7 +55,8 @@ export const AUTH_CONFIG = {
 	},
 };
 
-export const PUBLIC_ROUTES = ["/", "/sign-in", "/sign-up", "/forgot-password"];
+export const PUBLIC_ROUTES = ["/", /^\/sign-in/, /^\/sign-up/, /^\/forgot-password/];
+export const API_MIDDLEWARE_PUBLIC_ROUTES = [/^\/health/, /^\/api\/auth/];
 
 export const THEME_CONFIG = {
 	accessKey: "fallback-theme",

--- a/packages/shared/constants.ts
+++ b/packages/shared/constants.ts
@@ -55,8 +55,17 @@ export const AUTH_CONFIG = {
 	},
 };
 
-export const PUBLIC_ROUTES = ["/", /^\/sign-in/, /^\/sign-up/, /^\/forgot-password/];
-export const API_MIDDLEWARE_PUBLIC_ROUTES = [/^\/health/, /^\/api\/auth/];
+export const PUBLIC_ROUTES = [
+	/^\/sign-in(\/.*)?$/,
+	/^\/sign-up(\/.*)?$/,
+	/^\/forgot-password(\/.*)?$/,
+	"/",
+];
+
+export const API_MIDDLEWARE_PUBLIC_ROUTES = [
+	/^\/health/,
+	/^\/api\/auth(\/.*)?$/,
+];
 
 export const THEME_CONFIG = {
 	accessKey: "fallback-theme",


### PR DESCRIPTION
## Why 
Client public routes had a bit of an issue and CodeRabbit mentioned that this would only support the exact path and not variations of it.

## What 
- Ensures that we handle all cases by changing how the path matches
- Refactors both route options into the shared constants

## Tested 
Ensures protected paths are properly protected 


## Satisfies 
#61 